### PR TITLE
fix: bump @frames.js/render to fix client side button actions

### DIFF
--- a/apps/server/package.json
+++ b/apps/server/package.json
@@ -9,7 +9,7 @@
     "lint": "next lint"
   },
   "dependencies": {
-    "@frames.js/render": "^0.2.12",
+    "@frames.js/render": "^0.2.16",
     "@noble/ed25519": "^2.0.0",
     "@rainbow-me/rainbowkit": "^2.1.0",
     "@reservoir0x/reservoir-sdk": "^2.2.3",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -91,8 +91,8 @@ importers:
   apps/server:
     dependencies:
       '@frames.js/render':
-        specifier: ^0.2.12
-        version: 0.2.12(@cloudflare/workers-types@4.20240605.0)(@lens-protocol/client@2.2.0)(@types/express@4.17.21)(@xmtp/frames-validator@0.6.1)(@xmtp/proto@3.61.1)(next@14.1.4)(react-dom@18.2.0)(react@18.2.0)(typescript@5.4.5)(viem@2.13.7)(zod@3.23.8)
+        specifier: ^0.2.16
+        version: 0.2.16(@cloudflare/workers-types@4.20240605.0)(@lens-protocol/client@2.2.0)(@types/express@4.17.21)(@xmtp/frames-validator@0.6.1)(@xmtp/proto@3.61.1)(next@14.1.4)(react-dom@18.2.0)(react@18.2.0)(typescript@5.4.5)(viem@2.13.7)(zod@3.23.8)
       '@noble/ed25519':
         specifier: ^2.0.0
         version: 2.1.0
@@ -2467,8 +2467,8 @@ packages:
       - zod
     dev: true
 
-  /@frames.js/render@0.2.12(@cloudflare/workers-types@4.20240605.0)(@lens-protocol/client@2.2.0)(@types/express@4.17.21)(@xmtp/frames-validator@0.6.1)(@xmtp/proto@3.61.1)(next@14.1.4)(react-dom@18.2.0)(react@18.2.0)(typescript@5.4.5)(viem@2.13.7)(zod@3.23.8):
-    resolution: {integrity: sha512-Jw97jkwAYUSZYQUD7L+VgJwvDgrshdlMH0MUdCL7uizFFyyYLXGfp/jaxfUt5nDG0wRFd4+mF5+lp+qKRWzUOg==}
+  /@frames.js/render@0.2.16(@cloudflare/workers-types@4.20240605.0)(@lens-protocol/client@2.2.0)(@types/express@4.17.21)(@xmtp/frames-validator@0.6.1)(@xmtp/proto@3.61.1)(next@14.1.4)(react-dom@18.2.0)(react@18.2.0)(typescript@5.4.5)(viem@2.13.7)(zod@3.23.8):
+    resolution: {integrity: sha512-wbrz6xfhUFH84GMz9lyCGn7CjHFCWp3W9ukuwujCKc35MhH5Xir8uBX3tctNWul2U5DAH2/VXvhv9lXj7xL9KA==}
     peerDependencies:
       next: ^14.1.0
       react: ^18.2.0
@@ -2476,7 +2476,7 @@ packages:
       viem: ^2.7.8
     dependencies:
       '@farcaster/core': 0.14.13(typescript@5.4.5)(zod@3.23.8)
-      frames.js: 0.16.5(@cloudflare/workers-types@4.20240605.0)(@lens-protocol/client@2.2.0)(@types/express@4.17.21)(@xmtp/frames-validator@0.6.1)(@xmtp/proto@3.61.1)(next@14.1.4)(react-dom@18.2.0)(react@18.2.0)(typescript@5.4.5)(zod@3.23.8)
+      frames.js: 0.17.1(@cloudflare/workers-types@4.20240605.0)(@lens-protocol/client@2.2.0)(@types/express@4.17.21)(@xmtp/frames-validator@0.6.1)(@xmtp/proto@3.61.1)(next@14.1.4)(react-dom@18.2.0)(react@18.2.0)(typescript@5.4.5)(zod@3.23.8)
       next: 14.1.4(@babel/core@7.24.7)(react-dom@18.2.0)(react@18.2.0)
       react: 18.2.0
       react-dom: 18.2.0(react@18.2.0)
@@ -11008,6 +11008,37 @@ packages:
 
   /frames.js@0.16.5(@cloudflare/workers-types@4.20240605.0)(@lens-protocol/client@2.2.0)(@types/express@4.17.21)(@xmtp/frames-validator@0.6.1)(@xmtp/proto@3.61.1)(next@14.1.4)(react-dom@18.2.0)(react@18.2.0)(typescript@5.4.5)(zod@3.23.8):
     resolution: {integrity: sha512-GhN96mU29d5torOTNbXEpv8PPGVA7E3gqzxr/NEZ7+ZQLajTN+uF0/jZGf/5z2axAdR7R8uVmq5buSF8CGAtUA==}
+    peerDependencies:
+      '@cloudflare/workers-types': ^4.20240320.1
+      '@lens-protocol/client': ^2.0.0
+      '@types/express': ^4.17.21
+      '@xmtp/frames-validator': ^0.6.1
+      '@xmtp/proto': ^3.58.0
+      next: ^14.1.0
+      react: ^18.2.0
+      react-dom: ^18.2.0
+    dependencies:
+      '@cloudflare/workers-types': 4.20240605.0
+      '@lens-protocol/client': 2.2.0(@lens-protocol/metadata@1.2.0)(@types/react@18.3.3)(encoding@0.1.13)(ethers@6.13.0)(react@18.2.0)
+      '@types/express': 4.17.21
+      '@vercel/og': 0.6.2
+      '@xmtp/frames-validator': 0.6.1(typescript@5.4.5)(zod@3.23.8)
+      '@xmtp/proto': 3.61.1
+      cheerio: 1.0.0-rc.12
+      next: 14.1.4(@babel/core@7.24.7)(react-dom@18.2.0)(react@18.2.0)
+      protobufjs: 7.3.0
+      react: 18.2.0
+      react-dom: 18.2.0(react@18.2.0)
+      viem: 2.13.7(typescript@5.4.5)(zod@3.23.8)
+    transitivePeerDependencies:
+      - bufferutil
+      - typescript
+      - utf-8-validate
+      - zod
+    dev: false
+
+  /frames.js@0.17.1(@cloudflare/workers-types@4.20240605.0)(@lens-protocol/client@2.2.0)(@types/express@4.17.21)(@xmtp/frames-validator@0.6.1)(@xmtp/proto@3.61.1)(next@14.1.4)(react-dom@18.2.0)(react@18.2.0)(typescript@5.4.5)(zod@3.23.8):
+    resolution: {integrity: sha512-aCkxFSCx4jnaLyiIoAaPir3XUbxZRYcHonGt+VGzArOz6pnOjue3TM0v45YNIjrmJ+4Gw3Wplgx7em2xo8JuTw==}
     peerDependencies:
       '@cloudflare/workers-types': ^4.20240320.1
       '@lens-protocol/client': ^2.0.0


### PR DESCRIPTION
onSignerlessPress is no longer triggered for client side button actions (mint/link) in 0.2.16