### PR TITLE
feat: firefox support

### DIFF
--- a/apps/extension/package.json
+++ b/apps/extension/package.json
@@ -7,6 +7,7 @@
   "scripts": {
     "dev": "plasmo dev",
     "build": "plasmo build",
+    "build:all": "plasmo build --target=firefox-mv2 && plasmo build --target=chrome-mv3 && plasmo build --target=safari-mv3",
     "package": "plasmo package"
   },
   "dependencies": {
@@ -36,6 +37,12 @@
   "manifest": {
     "host_permissions": [
       "https://x.com/*"
-    ]
+    ],
+    "browser_specific_settings": {
+      "gecko": {
+        "id": "extension@frames.fun",
+        "strict_min_version": "0.0.1"
+      }
+    }
   }
 }

--- a/apps/server/app/api/options.ts
+++ b/apps/server/app/api/options.ts
@@ -1,0 +1,5 @@
+import { NextRequest } from "next/server";
+
+export const OPTIONS = (req: NextRequest) => {
+  return new Response(null);
+};

--- a/apps/server/app/api/v1/frames/route.ts
+++ b/apps/server/app/api/v1/frames/route.ts
@@ -1,1 +1,2 @@
 export { GET, POST } from "@frames.js/render/next";
+export { OPTIONS } from "../../options";

--- a/apps/server/app/api/v1/mint/route.ts
+++ b/apps/server/app/api/v1/mint/route.ts
@@ -10,6 +10,8 @@ import {
 } from "viem";
 import * as viemChains from "viem/chains";
 
+export { OPTIONS } from "../../options";
+
 export async function GET(request: NextRequest) {
   try {
     const searchParams = request.nextUrl.searchParams;

--- a/apps/server/app/api/v1/signer/route.ts
+++ b/apps/server/app/api/v1/signer/route.ts
@@ -1,6 +1,8 @@
 import { NextRequest, NextResponse } from "next/server";
 import { mnemonicToAccount } from "viem/accounts";
 
+export { OPTIONS } from "../../options";
+
 type SignedKeyRequestSponsorship = {
   sponsorFid: number;
   signature: string; // sponsorship signature by sponsorFid

--- a/apps/server/next.config.mjs
+++ b/apps/server/next.config.mjs
@@ -9,12 +9,11 @@ const nextConfig = {
           { key: "Access-Control-Allow-Origin", value: "*" },
           {
             key: "Access-Control-Allow-Methods",
-            value: "GET,DELETE,PATCH,POST,PUT",
+            value: "*",
           },
           {
             key: "Access-Control-Allow-Headers",
-            value:
-              "X-CSRF-Token, X-Requested-With, Accept, Accept-Version, Content-Length, Content-MD5, Content-Type, Date, X-Api-Version",
+            value: "*",
           },
         ],
       },


### PR DESCRIPTION
This PR adds support for firefox by complying to stricter cross-origin policy requirements. 

There is an unresolved issue whereby we cannot create a new keypair because the array buffer belongs to an insecure context
- Open issue here: https://bugzilla.mozilla.org/show_bug.cgi?id=1681809
- https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Errors/Property_access_denied