### PR TITLE
fix: reduce permissions scope

### DIFF
--- a/apps/extension/contents/auth-modal.tsx
+++ b/apps/extension/contents/auth-modal.tsx
@@ -13,7 +13,7 @@ export const getStyle = () => {
 }
 
 export const config: PlasmoCSConfig = {
-  matches: ["https://twitter.com/*", "https://x.com/*"]
+  matches: ["https://x.com/*"]
 }
 
 interface AuthModalContainerProps extends React.PropsWithChildren {

--- a/apps/extension/contents/frames.tsx
+++ b/apps/extension/contents/frames.tsx
@@ -11,7 +11,7 @@ import { sendToBackground } from "@plasmohq/messaging"
 import FrameIFrame from "~components/frame-iframe"
 
 export const config: PlasmoCSConfig = {
-  matches: ["https://twitter.com/*", "https://x.com/*"]
+  matches: ["https://x.com/*"]
 }
 
 export const getStyle = () => {

--- a/apps/extension/contents/load-test.ts
+++ b/apps/extension/contents/load-test.ts
@@ -1,9 +1,0 @@
-import type { PlasmoCSConfig } from "plasmo"
-
-export const config: PlasmoCSConfig = {
-  matches: ["https://not-twitter.com/*", "https://not-x.com/*"]
-}
-
-window.addEventListener("load", () => {
-  alert("LOADED")
-})


### PR DESCRIPTION
- Removes a testing file which added 2 nonexistent paths
- Removes twitter.com since it redirects to x.com automatically
![telegram-cloud-photo-size-4-5780522507625939856-x](https://github.com/mod-protocol/Frames-Fun-Extension/assets/5469870/e0ee273e-b672-4bac-93ab-2ec21d775151)
