### PR TITLE
fix: prevent NaN aspect ratio

### DIFF
--- a/apps/extension/components/frame-iframe.tsx
+++ b/apps/extension/components/frame-iframe.tsx
@@ -34,6 +34,13 @@ export default function FrameIFrame({ url, frameId, theme }: FrameIFrameProps) {
         return
       }
 
+      const newAspectRatio = message.data.width / message.data.height
+
+      if (Number.isNaN(newAspectRatio)) {
+        // keep default aspect ratio
+        return
+      }
+
       setAspectRatio(message.data.width / message.data.height)
     })
   }, [frameId])


### PR DESCRIPTION
This PR adds a check to prevent NaN aspect ratio which can happen when the width and height are resolved to 0. 

This can happen when hooks used to measure dimensions of element return null or 0.